### PR TITLE
fix(woodcutter): model and #base texture UV-mapping

### DIFF
--- a/src/main/resources/assets/corail_woodcutter/models/block/woodcutter.json
+++ b/src/main/resources/assets/corail_woodcutter/models/block/woodcutter.json
@@ -8,68 +8,96 @@
   },
   "elements": [
     {
-		"name": "table",
+		"name": "table1",
 		"from": [0, 8, 3],
+		"to": [16, 9, 6],
+		"faces": {
+			"north": {"uv": [0, 7, 16, 8], "texture": "#base"},
+			"east": {"uv": [10, 7, 13, 8], "texture": "#base"},
+			"west": {"uv": [3, 7, 6, 8], "texture": "#base"},
+			"up": {"uv": [0, 3, 16, 6], "texture": "#base"},
+			"down": {"uv": [0, 10, 16, 13], "texture": "#base"}
+		}
+	}, {
+		"name": "table2",
+		"from": [0, 8, 10],
 		"to": [16, 9, 13],
 		"faces": {
-			"north": {"uv": [0, 15, 16, 16], "texture": "#base"},
-			"east": {"uv": [4, 15, 12, 16], "texture": "#base"},
-			"south": {"uv": [0, 15, 16, 16], "texture": "#base"},
-			"west": {"uv": [4, 15, 12, 16], "texture": "#base"},
-			"up": {"uv": [0, 0, 16, 10], "texture": "#base"},
-			"down": {"uv": [0, 0, 16, 10], "rotation": 180, "texture": "#base"}
+			"east": {"uv": [3, 7, 6, 8], "texture": "#base"},
+			"south": {"uv": [0, 7, 16, 8], "texture": "#base"},
+			"west": {"uv": [10, 7, 13, 8], "texture": "#base"},
+			"up": {"uv": [0, 10, 16, 13], "texture": "#base"},
+			"down": {"uv": [0, 3, 16, 6], "texture": "#base"}
+		}
+	}, {
+		"name": "table3",
+		"from": [0, 8, 6],
+		"to": [1, 9, 10],
+		"faces": {
+			"west": {"uv": [6, 7, 10, 8], "texture": "#base"},
+			"up": {"uv": [0, 6, 1, 10], "texture": "#base"},
+			"down": {"uv": [0, 6, 1, 10], "texture": "#base"}
+		}
+	}, {
+		"name": "table4",
+		"from": [15, 8, 6],
+		"to": [16, 9, 10],
+		"faces": {
+			"east": {"uv": [6, 7, 10, 8], "texture": "#base"},
+			"up": {"uv": [15, 6, 16, 10], "texture": "#base"},
+			"down": {"uv": [15, 6, 16, 10], "texture": "#base"}
 		}
 	}, {
 		"name": "top",
-		"from": [1, 7.995, 6],
-		"to": [15, 9.005, 10],
+		"from": [1, 8, 6],
+		"to": [15, 9, 10],
 		"faces": {
 			"up": {"uv": [1, 6, 15, 10], "texture": "#top"},
-			"down": {"uv": [1, 6, 15, 10], "rotation": 180, "texture": "#top"}
+			"down": {"uv": [1, 6, 15, 10], "texture": "#top"}
 		}
 	}, {
 		"name": "leg1",
 		"from": [13, 0, 5],
 		"to": [14, 8, 6],
 		"faces": {
-			"north": {"uv": [2, 0, 3, 8], "texture": "#base"},
-			"east": {"uv": [1, 0, 2, 8], "texture": "#base"},
-			"south": {"uv": [0, 0, 1, 8], "texture": "#base"},
-			"west": {"uv": [3, 0, 4, 8], "texture": "#base"},
-			"down": {"uv": [0, 0, 1, 1], "texture": "#base"}
+			"north": {"uv": [2, 8, 3, 16], "texture": "#base"},
+			"east": {"uv": [10, 8, 11, 16], "texture": "#base"},
+			"south": {"uv": [13, 8, 14, 16], "texture": "#base"},
+			"west": {"uv": [5, 8, 6, 16], "texture": "#base"},
+			"down": {"uv": [13, 10, 14, 11], "texture": "#base"}
 		}
 	}, {
 		"name": "leg2",
 		"from": [2, 0, 10],
 		"to": [3, 8, 11],
 		"faces": {
-			"north": {"uv": [2, 0, 3, 8], "texture": "#base"},
-			"east": {"uv": [1, 0, 2, 8], "texture": "#base"},
-			"south": {"uv": [0, 0, 1, 8], "texture": "#base"},
-			"west": {"uv": [3, 0, 4, 8], "texture": "#base"},
-			"down": {"uv": [0, 0, 1, 1], "texture": "#base"}
+			"north": {"uv": [13, 8, 14, 16], "texture": "#base"},
+			"east": {"uv": [5, 8, 6, 16], "texture": "#base"},
+			"south": {"uv": [2, 8, 3, 16], "texture": "#base"},
+			"west": {"uv": [10, 8, 11, 16], "texture": "#base"},
+			"down": {"uv": [2, 5, 3, 6], "texture": "#base"}
 		}
 	}, {
 		"name": "leg3",
 		"from": [13, 0, 10],
 		"to": [14, 8, 11],
 		"faces": {
-			"north": {"uv": [2, 0, 3, 8], "texture": "#base"},
-			"east": {"uv": [1, 0, 2, 8], "texture": "#base"},
-			"south": {"uv": [0, 0, 1, 8], "texture": "#base"},
-			"west": {"uv": [3, 0, 4, 8], "texture": "#base"},
-			"down": {"uv": [0, 0, 1, 1], "texture": "#base"}
+			"north": {"uv": [2, 8, 3, 16], "texture": "#base"},
+			"east": {"uv": [5, 8, 6, 16], "texture": "#base"},
+			"south": {"uv": [13, 8, 14, 16], "texture": "#base"},
+			"west": {"uv": [10, 8, 11, 16], "texture": "#base"},
+			"down": {"uv": [13, 5, 14, 6], "texture": "#base"}
 		}
 	}, {
 		"name": "leg4",
 		"from": [2, 0, 5],
 		"to": [3, 8, 6],
 		"faces": {
-			"north": {"uv": [2, 0, 3, 8], "texture": "#base"},
-			"east": {"uv": [1, 0, 2, 8], "texture": "#base"},
-			"south": {"uv": [0, 0, 1, 8], "texture": "#base"},
-			"west": {"uv": [3, 0, 4, 8], "texture": "#base"},
-			"down": {"uv": [0, 0, 1, 1], "texture": "#base"}
+			"north": {"uv": [13, 8, 14, 16], "texture": "#base"},
+			"east": {"uv": [10, 8, 11, 16], "texture": "#base"},
+			"south": {"uv": [2, 8, 3, 16], "texture": "#base"},
+			"west": {"uv": [5, 8, 6, 16], "texture": "#base"},
+			"down": {"uv": [2, 10, 3, 11], "texture": "#base"}
 		}
 	}, {
 		"name": "saw-top",
@@ -92,20 +120,20 @@
 		"from": [3, 5, 10],
 		"to": [13, 6, 11],
 		"faces": {
-			"north": {"uv": [3, 1, 13, 2], "texture": "#base"},
-			"south": {"uv": [3, 2, 13, 3], "texture": "#base"},
-			"up": {"uv": [3, 0, 13, 1], "texture": "#base"},
-			"down": {"uv": [3, 3, 13, 4], "texture": "#base"}
+			"north": {"uv": [3, 10, 13, 11], "texture": "#base"},
+			"south": {"uv": [3, 10, 13, 11], "texture": "#base"},
+			"up": {"uv": [3, 10, 13, 11], "texture": "#base"},
+			"down": {"uv": [3, 5, 13, 6], "texture": "#base"}
 		}
 	}, {
 		"name": "foot-link2",
 		"from": [3, 5, 5],
 		"to": [13, 6, 6],
 		"faces": {
-			"north": {"uv": [3, 2, 13, 3], "texture": "#base"},
-			"south": {"uv": [3, 1, 13, 2], "texture": "#base"},
-			"up": {"uv": [3, 0, 13, 1], "texture": "#base"},
-			"down": {"uv": [3, 3, 13, 4], "texture": "#base"}
+			"north": {"uv": [3, 10, 13, 11], "texture": "#base"},
+			"south": {"uv": [3, 10, 13, 11], "texture": "#base"},
+			"up": {"uv": [3, 5, 13, 6], "texture": "#base"},
+			"down": {"uv": [3, 10, 13, 11], "texture": "#base"}
 		}
 	}
   ]


### PR DESCRIPTION
- Fixes table top z-fighting with saw cut-out from stonecutter by splitting the table top in 4 elements, with a hole for the cut-uut panel.
- Fixes UV-mapping of `#base` texture, exactly matching element's location to get a seamless joint on connected elements.

Preview of the updated model:
![2022-11-21_02 08 55](https://user-images.githubusercontent.com/1111474/202937831-cd568867-ce9e-49ff-8403-7a83229d83a7.png)
